### PR TITLE
Correct build_menu output

### DIFF
--- a/showfaces/show.php
+++ b/showfaces/show.php
@@ -157,13 +157,8 @@ function build_menu($cid) {
 					
 				
    				<input type="submit" value="'.get_string('print', 'block_faces').'">
-				</span>
 				</form>
-				
-
-			    </div>
-			    
-
+				</span>
 				</div>
 				';
 	


### PR DESCRIPTION
Removes extra div closing tag.
corrects order of span and form closing tags.